### PR TITLE
Mangafreak integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and then `npm start` to start the electron application.
 
 ## Supported sites
 
-Right now the only supported site is mangareader.net. However, I plan on adding support for more manga sites in the future and it is also fairly easy to contribute bindings to a specific site.
+Right now the only supported sites are mangareader.net and mangafreak.net. However, I plan on adding support for more manga sites in the future and it is also fairly easy to contribute bindings to a specific site.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Right now the only supported site is mangareader.net. However, I plan on adding 
 
 ## Contributing
 
-Contributions for all parts of the application are welcome! The easiest contribution to make is adding support for a specific manga site. In order to do that, you should create a new file inside utils/sites and have it implement the functions mangaURL, parseMangaData, parsePageLinks, and parsePageImage (look at utils/sites/mangareader.js for an example). Then all you have to do is add a key-value pair to the hostnameAdapterMap object inside utils/url.js where the key is the hostname of the new manga site and the value is require('path to file you created').
+Contributions for all parts of the application are welcome! The easiest contribution to make is adding support for a specific manga site. In order to do that, you should create a new file inside utils/sites and have it implement the functions mangaURL, sendRequest, parseMangaData, parsePageLinks, and parsePageImage (look at utils/sites/mangareader.js for an example). Then all you have to do is add a key-value pair to the hostnameAdapterMap object inside utils/url.js where the key is the hostname of the new manga site and the value is require('path to file you created').
 
 The style checker for this project is [standard](https://github.com/feross/standard) so you should make sure that running standard in the project root doesn't result in any errors or warnings.
 

--- a/__tests__/reducers_manga.spec.js
+++ b/__tests__/reducers_manga.spec.js
@@ -1,4 +1,4 @@
-/* global test, expect */
+/* global test, expect, jasmine */
 
 import configureStore from '../client/configureStore.js'
 import { LOADED, NOT_LOADED, NOT_DOWNLOADED } from '../utils/constants.js'
@@ -10,6 +10,8 @@ import {
   VISIT_MANGA,
   DIFF_CHANGES
 } from '../client/actions/manga.js'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000
 
 test('manga reducer', () => {
   const store = configureStore(false)

--- a/__tests__/scraper_mangafreak.spec.js
+++ b/__tests__/scraper_mangafreak.spec.js
@@ -1,0 +1,35 @@
+/* global test, expect, jasmine */
+
+import scraper from '../utils/scraper.js'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000
+
+test('properly scrapes demi-chan chapter 1', () => {
+  const adapter = require('../utils/sites/mangafreak.js')
+
+  return scraper.scrapeChapter('http://www3.mangafreak.net/Read1_Ajin_Chan_Wa_Kataritai_1', adapter)
+    .then((imageURLs) => expect(imageURLs).toEqual([
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_1.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_2.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_3.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_4.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_5.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_6.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_7.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_8.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_9.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_10.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_11.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_12.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_13.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_14.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_15.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_16.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_17.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_18.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_19.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_20.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_21.jpg?v5',
+      'http://images.mangafreak.net/mangas/ajin_chan_wa_kataritai/ajin_chan_wa_kataritai_1/ajin_chan_wa_kataritai_1_22.jpg?v5'
+    ]))
+})

--- a/__tests__/scraper_mangafreak.spec.js
+++ b/__tests__/scraper_mangafreak.spec.js
@@ -2,7 +2,26 @@
 
 import scraper from '../utils/scraper.js'
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000
+
+test('properly scrapes demi-chan manga data', () => {
+  const adapter = require('../utils/sites/mangafreak.js')
+
+  return scraper.scrape('http://www3.mangafreak.net/Manga/Ajin_Chan_Wa_Kataritai', adapter)
+    .then((manga) => {
+      expect(manga.chapters.length).not.toEqual(0)
+      delete manga.chapters
+      expect(manga).toEqual({
+        type: 'www.mangafreak.net',
+        name: 'Ajin_Chan_Wa_Kataritai',
+        title: 'Ajin-chan wa Kataritai',
+        description: 'Succubus, Dullahan and Vampire. They are known as Ajin, or "demi"s and are slightly different than the average human. They have lived alongside humans for ages under persecution. However, in recent years, they have become accepted as members of society. This manga follows a high school biology teacher who has a great interest in demis and his interaction with the various demis in his school, each with their own cute problems.',
+        image: 'http://images.mangafreak.net/manga_images/ajin_chan_wa_kataritai.jpg',
+        new: true,
+        currentChapter: 0
+      })
+    })
+})
 
 test('properly scrapes demi-chan chapter 1', () => {
   const adapter = require('../utils/sites/mangafreak.js')

--- a/__tests__/scraper_mangareader.spec.js
+++ b/__tests__/scraper_mangareader.spec.js
@@ -1,6 +1,8 @@
-/* global test, expect */
+/* global test, expect, jasmine */
 
 import scraper from '../utils/scraper.js'
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000
 
 test('properly scrapes one punch man manga data', () => {
   const adapter = require('../utils/sites/mangareader.js')

--- a/client/components/ChapterViewComponent.js
+++ b/client/components/ChapterViewComponent.js
@@ -18,31 +18,23 @@ export default function ChapterViewComponent ({ manga, mangaName, chapterNum, ba
   const onlineURL = chapter.get('pages').get(currPage)
   const downloadState = chapter.get('download').get('state')
 
-  let imagePath = null
-  let local = false
-  switch (downloadState) {
-    case DOWNLOADING:
-    case NOT_DOWNLOADED:
-      imagePath = onlineURL
-      break
-    case DOWNLOADED:
-      local = true
-      imagePath = 'manga://' + path.join(specificManga.get('name'), chapterNum + '', encodeURIComponent(onlineURL))
-      break
-  }
-
-  const imageClicked = () => {
-    onImageClicked(specificManga, chapterNum)
-  }
-  const prevClicked = () => {
-    onPrevClicked(specificManga, chapterNum)
+  const imageClicked = () => onImageClicked(specificManga, chapterNum)
+  const prevClicked = () => onPrevClicked(specificManga, chapterNum)
+  const imageProps = {
+    style: { width: '100%' },
+    onClick: imageClicked
   }
 
   let imageComponent = null
-  if (local) {
-    imageComponent = <img src={imagePath} style={{ width: '100%' }} onClick={imageClicked} />
-  } else {
-    imageComponent = <ImageComponent src={imagePath} type={type} style={{ width: '100%' }} onClick={imageClicked} />
+  switch (downloadState) {
+    case DOWNLOADING:
+    case NOT_DOWNLOADED:
+      imageComponent = <ImageComponent src={onlineURL} type={type} {...imageProps} />
+      break
+    case DOWNLOADED:
+      const imagePath = 'manga://' + path.join(specificManga.get('name'), chapterNum + '', encodeURIComponent(onlineURL))
+      imageComponent = <img src={imagePath} {...imageProps} />
+      break
   }
 
   return (

--- a/client/components/ChapterViewComponent.js
+++ b/client/components/ChapterViewComponent.js
@@ -4,12 +4,14 @@ import NavigationArrowBack from 'material-ui/svg-icons/navigation/arrow-back'
 import ContentUndo from 'material-ui/svg-icons/content/undo'
 import IconButton from 'material-ui/IconButton'
 import path from 'path'
+import ImageComponent from './ImageComponent.js'
 
 import { NOT_DOWNLOADED, DOWNLOADING, DOWNLOADED } from '../../utils/constants.js'
 
 export default function ChapterViewComponent ({ manga, mangaName, chapterNum, back, onImageClicked, onPrevClicked }) {
   const specificManga = manga.get(mangaName)
   const chapter = specificManga.get('chapters').get(chapterNum)
+  const type = `http://${specificManga.get('type')}`
   const title = `${specificManga.get('title')} - ${chapter.get('name')}`
   const currPage = chapter.get('currentPage')
 
@@ -17,12 +19,14 @@ export default function ChapterViewComponent ({ manga, mangaName, chapterNum, ba
   const downloadState = chapter.get('download').get('state')
 
   let imagePath = null
+  let local = false
   switch (downloadState) {
     case DOWNLOADING:
     case NOT_DOWNLOADED:
       imagePath = onlineURL
       break
     case DOWNLOADED:
+      local = true
       imagePath = 'manga://' + path.join(specificManga.get('name'), chapterNum + '', encodeURIComponent(onlineURL))
       break
   }
@@ -34,6 +38,13 @@ export default function ChapterViewComponent ({ manga, mangaName, chapterNum, ba
     onPrevClicked(specificManga, chapterNum)
   }
 
+  let imageComponent = null
+  if (local) {
+    imageComponent = <img src={imagePath} style={{ width: '100%' }} onClick={imageClicked} />
+  } else {
+    imageComponent = <ImageComponent src={imagePath} type={type} style={{ width: '100%' }} onClick={imageClicked} />
+  }
+
   return (
     <div>
       <AppBar
@@ -43,7 +54,7 @@ export default function ChapterViewComponent ({ manga, mangaName, chapterNum, ba
         style={{ position: 'fixed' }}
       />
       <br /><br /><br /><br />
-      <img src={imagePath} style={{ width: '100%' }} onClick={imageClicked} />
+      {imageComponent}
     </div>
   )
 }

--- a/client/components/ImageComponent.js
+++ b/client/components/ImageComponent.js
@@ -1,6 +1,7 @@
 /* global Blob, URL */
 
 import React, { PropTypes } from 'react'
+import Avatar from 'material-ui/Avatar'
 import { adapterFromURL, fileExtFromURL } from '../../utils/url.js'
 import mimetype from 'mimetype'
 
@@ -8,11 +9,12 @@ export default class ImageComponent extends React.Component {
   constructor (props) {
     super(props)
 
-    const { src, type, ...imgProps } = props // eslint-disable-line
+    const { src, type, avatar, ...imgProps } = props // eslint-disable-line
     const adapter = adapterFromURL(type)
 
     this.adapter = adapter
     this.imgProps = imgProps
+    this.avatar = avatar
     this.state = { src: null }
   }
 
@@ -38,8 +40,14 @@ export default class ImageComponent extends React.Component {
 
   render () {
     if (this.state.src !== null) {
+      if (this.avatar) {
+        return <Avatar {...this.imgProps} src={this.state.src} />
+      }
       return <img {...this.imgProps} src={this.state.src} />
     } else {
+      if (this.avatar) {
+        return <Avatar {...this.imgProps} />
+      }
       return <div />
     }
   }
@@ -47,5 +55,8 @@ export default class ImageComponent extends React.Component {
 
 ImageComponent.propTypes = {
   src: PropTypes.string.isRequired,
-  type: PropTypes.string.isRequired
+  type: PropTypes.string.isRequired,
+  avatar: PropTypes.bool
 }
+
+ImageComponent.defaultProps = { avatar: false }

--- a/client/components/ImageComponent.js
+++ b/client/components/ImageComponent.js
@@ -1,0 +1,47 @@
+/* global URL */
+
+import React, { PropTypes } from 'react'
+import { adapterFromURL } from '../../utils/url.js'
+
+export default class ImageComponent extends React.Component {
+  constructor (props) {
+    super(props)
+
+    const { src, type, ...imgProps } = props // eslint-disable-line
+    const adapter = adapterFromURL(type)
+
+    this.adapter = adapter
+    this.imgProps = imgProps
+    this.state = { src: null }
+  }
+
+  retrieveImage (src) {
+    this.adapter.sendRequest(src, true).then((blob) => {
+      const url = URL.createObjectURL(blob)
+      this.setState({ src: url })
+    })
+  }
+
+  componentDidMount () {
+    this.retrieveImage(this.props.src)
+  }
+
+  componentWillUpdate (nextProps, nextState) {
+    if (nextProps.src !== this.props.src) {
+      this.retrieveImage(nextProps.src)
+    }
+  }
+
+  render () {
+    if (this.state.src !== null) {
+      return <img {...this.imgProps} src={this.state.src} />
+    } else {
+      return <div />
+    }
+  }
+}
+
+ImageComponent.propTypes = {
+  src: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired
+}

--- a/client/components/ImageComponent.js
+++ b/client/components/ImageComponent.js
@@ -1,7 +1,8 @@
-/* global URL */
+/* global Blob, URL */
 
 import React, { PropTypes } from 'react'
-import { adapterFromURL } from '../../utils/url.js'
+import { adapterFromURL, fileExtFromURL } from '../../utils/url.js'
+import mimetype from 'mimetype'
 
 export default class ImageComponent extends React.Component {
   constructor (props) {
@@ -16,7 +17,10 @@ export default class ImageComponent extends React.Component {
   }
 
   retrieveImage (src) {
-    this.adapter.sendRequest(src, true).then((blob) => {
+    this.adapter.sendRequest(src, true).then((buffer) => {
+      const fileExt = fileExtFromURL(src)
+      const fileType = mimetype.lookup(`sample.${fileExt}`)
+      const blob = new Blob([buffer], { type: fileType })
       const url = URL.createObjectURL(blob)
       this.setState({ src: url })
     })

--- a/client/components/MangaViewComponent.js
+++ b/client/components/MangaViewComponent.js
@@ -7,6 +7,7 @@ import FlatButton from 'material-ui/FlatButton'
 import RaisedButton from 'material-ui/RaisedButton'
 import Dialog from 'material-ui/Dialog'
 
+import ImageComponent from './ImageComponent.js'
 import ChapterCellContainer from '../containers/ChapterCellContainer.js'
 
 const styles = {
@@ -28,7 +29,7 @@ const styles = {
   }
 }
 
-function titleComponent (description, imageURL, openDialog) {
+function titleComponent (type, description, imageURL, openDialog) {
   // Dummy variable that is always true to trick eslint >:)
   const isSecondary = true
   const deleteText = 'Delete manga'
@@ -40,7 +41,7 @@ function titleComponent (description, imageURL, openDialog) {
 
   return (
     <div style={styles.container}>
-      <img src={imageURL} style={styles.image} />
+      <ImageComponent src={imageURL} type={type} style={styles.image} />
       <div style={styles.div}>
         <h3>Description:</h3>
         <p>{textDescription}</p>
@@ -67,6 +68,7 @@ export default class MangaViewComponent extends React.Component {
     const specificManga = this.props.manga.get(this.props.name)
     const imageURL = specificManga.get('image')
     const description = specificManga.get('description')
+    const type = `http://${specificManga.get('type')}`
     const actions = [
       <FlatButton
         label='Yes, delete manga'
@@ -97,7 +99,7 @@ export default class MangaViewComponent extends React.Component {
           onRequestClose={this.handleClose}
         />
 
-        {titleComponent(description, imageURL, this.handleOpen)}
+        {titleComponent(type, description, imageURL, this.handleOpen)}
 
         <Table selectable={false}>
           <TableHeader displaySelectAll={false} adjustForCheckbox={false}>

--- a/client/components/SomeMangaComponent.js
+++ b/client/components/SomeMangaComponent.js
@@ -1,20 +1,22 @@
 import React, { PropTypes } from 'react'
 import { List, ListItem } from 'material-ui/List'
-import Avatar from 'material-ui/Avatar'
 import Subheader from 'material-ui/Subheader'
 import Divider from 'material-ui/Divider'
 import HeaderContainer from '../containers/HeaderContainer.js'
 import { Link } from 'react-router'
+import ImageComponent from './ImageComponent.js'
 
 function mangaComponent (manga) {
   const title = manga.get('title')
+  const type = `http://${manga.get('type')}`
+  const avatar = true
 
   return (
     <Link to={'/manga/' + manga.get('name')} style={{ textDecoration: 'none' }}>
       <ListItem
         primaryText={title}
         secondaryText={manga.get('description')}
-        leftAvatar={<Avatar src={manga.get('image')} />}
+        leftAvatar={<ImageComponent src={manga.get('image')} type={type} avatar={avatar} />}
       />
     </Link>
   )

--- a/client/configureStore.js
+++ b/client/configureStore.js
@@ -7,6 +7,7 @@ import { log } from './reducers/log.js'
 import { saveState, loadState } from './storage.js'
 import { hashHistory } from 'react-router'
 import throttle from 'lodash/throttle'
+import createLogger from 'redux-logger'
 
 import { listenForIpc } from './ipcListener.js'
 
@@ -19,11 +20,12 @@ export default function configureStore (loadFromDisk = true) {
     routing: routerReducer,
     toastr: toastrReducer
   })
+  const logger = createLogger()
 
   let store
   if (loadFromDisk) {
     const persistedState = loadState()
-    store = createStore(reducer, persistedState, applyMiddleware(thunk, middleware))
+    store = createStore(reducer, persistedState, applyMiddleware(thunk, middleware, logger))
 
     listenForIpc(store)
     store.subscribe(throttle(() => {

--- a/client/containers/ChapterViewContainer.js
+++ b/client/containers/ChapterViewContainer.js
@@ -14,12 +14,12 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(goBack())
   },
 
-  onImageClicked (mangaName, chapterNum) {
-    dispatch(updatePage(mangaName, chapterNum, 1))
+  onImageClicked (manga, chapterNum) {
+    dispatch(updatePage(manga, chapterNum, 1))
   },
 
-  onPrevClicked (mangaName, chapterNum) {
-    dispatch(updatePage(mangaName, chapterNum, -1))
+  onPrevClicked (manga, chapterNum) {
+    dispatch(updatePage(manga, chapterNum, -1))
   }
 })
 

--- a/client/reducers/manga.js
+++ b/client/reducers/manga.js
@@ -52,9 +52,10 @@ export function manga (state = initState, action) {
       return state.setIn([action.mangaName, 'chapters', action.chapterNum, 'download', 'progress'], action.curr)
     case DOWNLOAD_CHAPTER:
       // Sends ipc call with the chapter's pages.
-      const [mangaName, chapterNum] = [action.mangaName, action.chapterNum]
+      const { mangaName, chapterNum } = action
+      const type = state.getIn([mangaName, 'type'])
       const pages = state.getIn([mangaName, 'chapters', chapterNum, 'pages']).toJS()
-      ipcRenderer.send('download-chapter', { mangaName, chapterNum, pages })
+      ipcRenderer.send('download-chapter', { mangaName, chapterNum, pages, type })
       return state
     case UPDATE_CHAPTER:
       return state.setIn([action.mangaName, 'currentChapter'], action.chapterNum)

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel-register": "^6.18.0",
     "bluebird": "^3.4.7",
     "cheerio": "^0.22.0",
+    "cloudscraper": "^1.4.1",
     "fs-extra": "^1.0.0",
     "immutable": "^3.8.1",
     "lodash": "^4.17.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "immutable": "^3.8.1",
     "lodash": "^4.17.3",
     "material-ui": "^0.16.5",
+    "mimetype": "0.0.8",
     "node-fetch": "^1.6.3",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
@@ -37,6 +38,7 @@
     "react-router-redux": "^4.0.7",
     "react-tap-event-plugin": "^2.0.1",
     "redux": "^3.6.0",
+    "redux-logger": "^2.7.4",
     "redux-thunk": "^2.1.0"
   }
 }

--- a/utils/process.js
+++ b/utils/process.js
@@ -58,12 +58,13 @@ function downloadProcessHandler (path, file) {
   startQueue(path, file, (msg) => sender.add(msg)).then((queue) => {
     process.send({ start: true })
     process.on('message', (msg) => {
-      const [mangaName, chapterNum] = [msg.mangaName, msg.chapterNum]
+      const { mangaName, chapterNum, type } = msg
       // Enqueue download tasks for each image.
       msg.pages.forEach((url, i) => {
         queue.enqueue({
           mangaName,
           chapterNum,
+          type,
           url,
           total: msg.pages.length,
           curr: i

--- a/utils/scraper.js
+++ b/utils/scraper.js
@@ -1,5 +1,3 @@
-const fetch = require('node-fetch')
-
 /**
  * Scrapes a specific chapter for the manga given the url to the chapter.
  * @param {string} url
@@ -7,13 +5,11 @@ const fetch = require('node-fetch')
  * @return {Promise<[string]>} an array of image urls for each page in the chapter.
  */
 function scrapeChapter (url, adapter) {
-  return fetch(url)
-    .then((res) => res.text())
+  return adapter.sendRequest(url)
     .then((body) => Promise.resolve(adapter.parsePageLinks(body)))
     .then((links) => {
       return Promise.all(links.map((link) => {
-        return fetch(link)
-          .then((res) => res.text())
+        return adapter.sendRequest(link)
           .then((body) => adapter.parsePageImage(body))
       }))
     })
@@ -28,8 +24,7 @@ function scrapeChapter (url, adapter) {
 function scrape (url, adapter) {
   const mangaName = url.substring(url.lastIndexOf('/') + 1, url.length)
 
-  return fetch(url)
-    .then((res) => res.text())
+  return adapter.sendRequest(url)
     .then((body) => adapter.parseMangaData(mangaName, body))
 }
 

--- a/utils/sites/mangafreak.js
+++ b/utils/sites/mangafreak.js
@@ -1,0 +1,47 @@
+import cheerio from 'cheerio'
+import cloudscraper from 'cloudscraper'
+
+export let adapterNotLoaded = true
+
+export function sendRequest (url) {
+  return new Promise((resolve, reject) => {
+    cloudscraper.get(url, function (err, resp, body) {
+      if (err) {
+        return reject(err)
+      }
+
+      resolve(body)
+    })
+  })
+}
+
+export function mangaURL (mangaName, chapterNum = null, pageNum = null) {
+  if (chapterNum !== null && pageNum !== null) {
+    return `http://www.mangafreak.net/Read1_${mangaName}_${chapterNum}_${pageNum}#gohere`
+  } else if (chapterNum !== null) {
+    return `http://www.mangafreak.net/Read1_${mangaName}_${chapterNum}`
+  } else {
+    return `http://www.mangafreak.net/Manga/${mangaName}`
+  }
+}
+
+export function parseMangaData (mangaName, body) {
+  // TODO(DarinM223): implement this
+}
+
+export function parsePageLinks (body) {
+  const $ = cheerio.load(body)
+
+  let links = []
+  $('.read_selector option').each(function (idx, option) {
+    const url = `http://www.mangafreak.net${option.attribs.value}`
+    links.push(url)
+  })
+
+  return links
+}
+
+export function parsePageImage (body) {
+  const $ = cheerio.load(body)
+  return $('#gohere').attr('src')
+}

--- a/utils/sites/mangafreak.js
+++ b/utils/sites/mangafreak.js
@@ -1,16 +1,32 @@
+/* global Blob */
 import cheerio from 'cheerio'
 import cloudscraper from 'cloudscraper'
 import { NOT_LOADED, NOT_DOWNLOADED } from '../constants.js'
+import { fileExtFromURL } from '../url.js'
+import mimetype from 'mimetype'
 
-export function sendRequest (url) {
+export function sendRequest (url, blob = false) {
   return new Promise((resolve, reject) => {
-    cloudscraper.get(url, function (err, resp, body) {
-      if (err) {
-        return reject(err)
-      }
+    if (blob) {
+      const fileExt = fileExtFromURL(url)
+      const fileType = mimetype.lookup(`sample.${fileExt}`)
 
-      resolve(body)
-    })
+      cloudscraper.request({ method: 'GET', url: url, encoding: null }, function (err, resp, body) {
+        if (err) {
+          return reject(err)
+        }
+
+        resolve(new Blob([body], { type: fileType }))
+      })
+    } else {
+      cloudscraper.get(url, function (err, resp, body) {
+        if (err) {
+          return reject(err)
+        }
+
+        resolve(body)
+      })
+    }
   })
 }
 

--- a/utils/sites/mangareader.js
+++ b/utils/sites/mangareader.js
@@ -55,6 +55,8 @@ export function parseMangaData (mangaName, body) {
         }
       })
 
+      // Chapters are in increasing order (chapter 1 would
+      // have a smaller index than chapter 50).
       chapters.push({
         name,
         url,

--- a/utils/sites/mangareader.js
+++ b/utils/sites/mangareader.js
@@ -1,4 +1,5 @@
 import cheerio from 'cheerio'
+import fetch from 'node-fetch'
 import { NOT_LOADED, NOT_DOWNLOADED } from '../constants.js'
 
 /**
@@ -17,6 +18,15 @@ export function mangaURL (mangaName, chapterNum = null, pageNum = null) {
   } else {
     return `http://www.mangareader.net/${mangaName}`
   }
+}
+
+/**
+ * Sends a request to the specified url and
+ * returns a Promise that contains the body of the response.
+ * @return {Promise<string>} the body of the response
+ */
+export function sendRequest (url) {
+  return fetch(url).then((res) => res.text())
 }
 
 /**

--- a/utils/sites/mangareader.js
+++ b/utils/sites/mangareader.js
@@ -1,10 +1,6 @@
-/* global Blob */
-
-import cheerio from 'cheerio'
-import fetch from 'node-fetch'
-import { NOT_LOADED, NOT_DOWNLOADED } from '../constants.js'
-import { fileExtFromURL } from '../url.js'
-import mimetype from 'mimetype'
+const cheerio = require('cheerio')
+const fetch = require('node-fetch')
+const { NOT_LOADED, NOT_DOWNLOADED } = require('../constants.js')
 
 /**
  * Returns the URL for the given manga. If chapterNum or pageNum is also
@@ -14,7 +10,7 @@ import mimetype from 'mimetype'
  * @param {number|null} pageNum
  * @return {string} the requested URL.
  */
-export function mangaURL (mangaName, chapterNum = null, pageNum = null) {
+function mangaURL (mangaName, chapterNum = null, pageNum = null) {
   if (chapterNum !== null && pageNum !== null) {
     return `http://www.mangareader.net/${mangaName}/${chapterNum}/${pageNum}`
   } else if (chapterNum !== null) {
@@ -27,16 +23,12 @@ export function mangaURL (mangaName, chapterNum = null, pageNum = null) {
 /**
  * Sends a request to the specified url and
  * returns a Promise that contains the body of the response.
- * @param {boolean} blob optional parameter that if true specifies that the response must return a blob.
+ * @param {boolean} buffer optional parameter that if true specifies that the response must return an arraybuffer.
  * @return {Promise<string>} the body of the response
  */
-export function sendRequest (url, blob = false) {
-  if (blob) {
-    const fileExt = fileExtFromURL(url)
-    const fileType = mimetype.lookup(`sample.${fileExt}`)
-    return fetch(url)
-      .then((res) => res.buffer())
-      .then((buf) => new Blob([buf], { type: fileType }))
+function sendRequest (url, buffer = false) {
+  if (buffer) {
+    return fetch(url).then((res) => res.buffer())
   }
   return fetch(url).then((res) => res.text())
 }
@@ -47,7 +39,7 @@ export function sendRequest (url, blob = false) {
  * @param {string} body
  * @return {object} the manga as a nested object.
  */
-export function parseMangaData (mangaName, body) {
+function parseMangaData (mangaName, body) {
   const $ = cheerio.load(body)
 
   const title = $('#mangaproperties h1').text().trim()
@@ -101,7 +93,7 @@ export function parseMangaData (mangaName, body) {
  * @param {string} body
  * @return {[string]} the page links in the chapter.
  */
-export function parsePageLinks (body) {
+function parsePageLinks (body) {
   const $ = cheerio.load(body)
 
   let links = []
@@ -118,7 +110,15 @@ export function parsePageLinks (body) {
  * @param {string} body
  * @return {string} the image URL of the page.
  */
-export function parsePageImage (body) {
+function parsePageImage (body) {
   const $ = cheerio.load(body)
   return $('#img').attr('src')
+}
+
+module.exports = {
+  mangaURL,
+  sendRequest,
+  parseMangaData,
+  parsePageLinks,
+  parsePageImage
 }

--- a/utils/sites/mangareader.js
+++ b/utils/sites/mangareader.js
@@ -1,6 +1,10 @@
+/* global Blob */
+
 import cheerio from 'cheerio'
 import fetch from 'node-fetch'
 import { NOT_LOADED, NOT_DOWNLOADED } from '../constants.js'
+import { fileExtFromURL } from '../url.js'
+import mimetype from 'mimetype'
 
 /**
  * Returns the URL for the given manga. If chapterNum or pageNum is also
@@ -23,9 +27,17 @@ export function mangaURL (mangaName, chapterNum = null, pageNum = null) {
 /**
  * Sends a request to the specified url and
  * returns a Promise that contains the body of the response.
+ * @param {boolean} blob optional parameter that if true specifies that the response must return a blob.
  * @return {Promise<string>} the body of the response
  */
-export function sendRequest (url) {
+export function sendRequest (url, blob = false) {
+  if (blob) {
+    const fileExt = fileExtFromURL(url)
+    const fileType = mimetype.lookup(`sample.${fileExt}`)
+    return fetch(url)
+      .then((res) => res.buffer())
+      .then((buf) => new Blob([buf], { type: fileType }))
+  }
   return fetch(url).then((res) => res.text())
 }
 

--- a/utils/url.js
+++ b/utils/url.js
@@ -23,3 +23,28 @@ export function validHostname (url) {
   const hostname = hostnameFromURL(url)
   return hostname in hostnameAdapterMap
 }
+
+export function fileExtFromURL (url) {
+  let lastDotIdx = -1
+  for (let i = url.length - 1; i >= 0; i--) {
+    if (url[i] === '.') {
+      lastDotIdx = i
+      break
+    }
+  }
+
+  if (lastDotIdx === -1) {
+    return null
+  }
+
+  let fileExt = ''
+  for (let i = lastDotIdx + 1; i < url.length; i++) {
+    const ch = url[i].toLowerCase()
+    if (ch < 'a' || ch > 'z') {
+      break
+    }
+    fileExt += url[i]
+  }
+
+  return fileExt
+}

--- a/utils/url.js
+++ b/utils/url.js
@@ -10,21 +10,21 @@ const hostnameAdapterMap = {
   'www3.mangafreak.net': require('./sites/mangafreak.js')
 }
 
-export function adapterFromURL (url) {
+function adapterFromURL (url) {
   const hostname = hostnameFromURL(url)
   return adapterFromHostname(hostname)
 }
 
-export function adapterFromHostname (hostname) {
+function adapterFromHostname (hostname) {
   return hostnameAdapterMap[hostname]
 }
 
-export function validHostname (url) {
+function validHostname (url) {
   const hostname = hostnameFromURL(url)
   return hostname in hostnameAdapterMap
 }
 
-export function fileExtFromURL (url) {
+function fileExtFromURL (url) {
   let lastDotIdx = -1
   for (let i = url.length - 1; i >= 0; i--) {
     if (url[i] === '.') {
@@ -47,4 +47,11 @@ export function fileExtFromURL (url) {
   }
 
   return fileExt
+}
+
+module.exports = {
+  adapterFromURL,
+  adapterFromHostname,
+  validHostname,
+  fileExtFromURL
 }

--- a/utils/url.js
+++ b/utils/url.js
@@ -5,7 +5,9 @@ function hostnameFromURL (url) {
 }
 
 const hostnameAdapterMap = {
-  'www.mangareader.net': require('./sites/mangareader.js')
+  'www.mangareader.net': require('./sites/mangareader.js'),
+  'www.mangafreak.net': require('./sites/mangafreak.js'),
+  'www3.mangafreak.net': require('./sites/mangafreak.js')
 }
 
 export function adapterFromURL (url) {


### PR DESCRIPTION
Adds bindings to mangafreak, modifies the manga adapter api, and modifies the core code to handle images under cloudflare (or any image that requires a special async action to be fetched).

* sendRequest() method added to manga adapter api. It can retrieve a URL either as text or as an arraybuffer. Bindings to manga sites that use cloudflare would have to bypass cloudflare in this method.
* ImageComponent created for rendering images using the adapter's sendRequest() method and allows the output to be either as a normal image or as an avatar image
* Download chapter messages sent through ipc now includes a 'type' property that is the main hostname of the manga site that the images are being downloaded from, so that the download queue can determine the correct adapter to use.
* The download queue downloads the images using the adapter's sendRequest() method instead of fetch() so that images under cloudflare can be downloaded.