### PR TITLE
Improves page navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A desktop manga reader in Javascript using React and Redux.
 * You can download as many chapters as you want for offline reading.
 * Because the download state is persisted to disk you can close the app while it is downloading a chapter and it will resume the next time you start it up again.
 * The app automatically checks for and adds new chapters on startup.
+* You can navigate to the next/previous page by clicking the right/left side of the manga image. You can also jump directly to a certain page or use a slider to scroll quickly through pages.
 
 ![Screenshot](/screenshot.png)
 

--- a/client/components/ChapterViewComponent.js
+++ b/client/components/ChapterViewComponent.js
@@ -3,23 +3,11 @@ import AppBar from 'material-ui/AppBar'
 import NavigationArrowBack from 'material-ui/svg-icons/navigation/arrow-back'
 import NavigationArrowDropDown from 'material-ui/svg-icons/navigation/arrow-drop-down'
 import IconButton from 'material-ui/IconButton'
-import Slider from 'material-ui/Slider'
 import path from 'path'
 import ImageComponent from './ImageComponent.js'
+import SliderComponent from './SliderComponent.js'
 
 import { NOT_DOWNLOADED, DOWNLOADING, DOWNLOADED } from '../../utils/constants.js'
-
-const styles = {
-  slider: {
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-around'
-  },
-  sliderText: {
-    position: 'relative',
-    top: '5px'
-  }
-}
 
 export default class ChapterViewComponent extends React.Component {
   constructor (props) {
@@ -52,6 +40,8 @@ export default class ChapterViewComponent extends React.Component {
     const downloadState = chapter.get('download').get('state')
 
     const imageClicked = (xOffset, yOffset, dimensions) => {
+      // If click was on the right half of the image then go to the next page,
+      // otherwise go to the previous page.
       if (xOffset > dimensions.width / 2) {
         this.updateSlider(this.state.slider + 1, totalPages)
         this.props.update(specificManga, this.props.chapterNum, 1)
@@ -60,51 +50,51 @@ export default class ChapterViewComponent extends React.Component {
         this.props.update(specificManga, this.props.chapterNum, -1)
       }
     }
+
     const dropDownClicked = () => this.setState({ navigationVisible: !this.state.navigationVisible })
-    const sliderChanged = (event, newValue) => {
-      this.updateSlider(newValue, totalPages)
-      const diff = newValue - currPage - 1
+
+    const sliderChanged = (value) => {
+      this.updateSlider(value, totalPages)
+      const diff = value - currPage - 1
 
       if (diff !== 0) {
         this.props.update(specificManga, this.props.chapterNum, diff)
       }
     }
-    const imageProps = {
-      style: { width: '100%' },
-      downloaded: false,
-      onImageClick: imageClicked
-    }
 
     let imagePath = null
-    switch (downloadState) {
-      case DOWNLOADING:
-      case NOT_DOWNLOADED:
-        imagePath = onlineURL
-        break
-      case DOWNLOADED:
-        imagePath = 'manga://' + path.join(
-          specificManga.get('name'),
-          this.props.chapterNum + '',
-          encodeURIComponent(onlineURL)
-        )
-        imageProps.downloaded = true
-        break
+    let downloaded = false
+    if (downloadState === DOWNLOADING || downloadState === NOT_DOWNLOADED) {
+      imagePath = onlineURL
+    } else if (downloadState === DOWNLOADED) {
+      imagePath = 'manga://' + path.join(
+        specificManga.get('name'),
+        this.props.chapterNum + '',
+        encodeURIComponent(onlineURL)
+      )
+      downloaded = true
+    } else {
+      throw new Error('Invalid download state')
     }
-    const imageComponent = <ImageComponent src={imagePath} type={type} {...imageProps} />
+
+    const imageComponent = (
+      <ImageComponent
+        src={imagePath}
+        type={type}
+        style={{ width: '100%' }}
+        downloaded={downloaded}
+        onImageClick={imageClicked}
+      />
+    )
+
     let sliderComponent = <div />
     if (this.state.navigationVisible) {
       sliderComponent = (
-        <div style={styles.slider}>
-          <Slider
-            style={{ width: '80%' }}
-            min={1}
-            max={totalPages}
-            step={1}
-            value={this.state.slider}
-            onChange={sliderChanged}
-          />
-          <p style={styles.sliderText}>{this.state.slider}/{totalPages}</p>
-        </div>
+        <SliderComponent
+          currValue={this.state.slider}
+          totalPages={totalPages}
+          onSliderChanged={sliderChanged}
+        />
       )
     }
 

--- a/client/components/ChapterViewComponent.js
+++ b/client/components/ChapterViewComponent.js
@@ -3,52 +3,112 @@ import AppBar from 'material-ui/AppBar'
 import NavigationArrowBack from 'material-ui/svg-icons/navigation/arrow-back'
 import ContentUndo from 'material-ui/svg-icons/content/undo'
 import IconButton from 'material-ui/IconButton'
+import Slider from 'material-ui/Slider'
 import path from 'path'
 import ImageComponent from './ImageComponent.js'
 
 import { NOT_DOWNLOADED, DOWNLOADING, DOWNLOADED } from '../../utils/constants.js'
 
-export default function ChapterViewComponent ({ manga, mangaName, chapterNum, back, onImageClicked, onPrevClicked }) {
-  const specificManga = manga.get(mangaName)
-  const chapter = specificManga.get('chapters').get(chapterNum)
-  const type = `http://${specificManga.get('type')}`
-  const title = `${specificManga.get('title')} - ${chapter.get('name')}`
-  const currPage = chapter.get('currentPage')
+const styles = {
+  slider: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-around'
+  },
+  sliderText: {
+    position: 'relative',
+    top: '5px'
+  }
+}
 
-  const onlineURL = chapter.get('pages').get(currPage)
-  const downloadState = chapter.get('download').get('state')
+export default class ChapterViewComponent extends React.Component {
+  constructor (props) {
+    super(props)
 
-  const imageClicked = () => onImageClicked(specificManga, chapterNum)
-  const prevClicked = () => onPrevClicked(specificManga, chapterNum)
-  const imageProps = {
-    style: { width: '100%' },
-    onClick: imageClicked
+    const specificManga = props.manga.get(props.mangaName)
+    const chapter = specificManga.get('chapters').get(props.chapterNum)
+    const currPage = chapter.get('currentPage')
+    this.state = { slider: currPage + 1 }
   }
 
-  let imageComponent = null
-  switch (downloadState) {
-    case DOWNLOADING:
-    case NOT_DOWNLOADED:
-      imageComponent = <ImageComponent src={onlineURL} type={type} {...imageProps} />
-      break
-    case DOWNLOADED:
-      const imagePath = 'manga://' + path.join(specificManga.get('name'), chapterNum + '', encodeURIComponent(onlineURL))
-      imageComponent = <img src={imagePath} {...imageProps} />
-      break
+  updateSlider (updatedValue, totalPages) {
+    if (updatedValue >= 1 && updatedValue <= totalPages) {
+      this.setState({ slider: updatedValue })
+    }
   }
 
-  return (
-    <div>
-      <AppBar
-        title={title}
-        iconElementLeft={<IconButton onClick={back}><NavigationArrowBack /></IconButton>}
-        iconElementRight={<IconButton onClick={prevClicked}><ContentUndo /></IconButton>}
-        style={{ position: 'fixed' }}
-      />
-      <br /><br /><br /><br />
-      {imageComponent}
-    </div>
-  )
+  render () {
+    const specificManga = this.props.manga.get(this.props.mangaName)
+    const chapter = specificManga.get('chapters').get(this.props.chapterNum)
+    const type = `http://${specificManga.get('type')}`
+    const title = `${specificManga.get('title')} - ${chapter.get('name')}`
+    const currPage = chapter.get('currentPage')
+
+    const onlineURL = chapter.get('pages').get(currPage)
+    const totalPages = chapter.get('pages').count()
+    const downloadState = chapter.get('download').get('state')
+
+    const imageClicked = () => {
+      this.updateSlider(this.state.slider + 1, totalPages)
+      this.props.update(specificManga, this.props.chapterNum, 1)
+    }
+    const prevClicked = () => {
+      this.updateSlider(this.state.slider - 1, totalPages)
+      this.props.update(specificManga, this.props.chapterNum, -1)
+    }
+    const sliderChanged = (event, newValue) => {
+      this.updateSlider(newValue, totalPages)
+      const diff = newValue - currPage - 1
+
+      if (diff !== 0) {
+        this.props.update(specificManga, this.props.chapterNum, diff)
+      }
+    }
+    const imageProps = {
+      style: { width: '100%' },
+      onClick: imageClicked
+    }
+
+    let imageComponent = null
+    switch (downloadState) {
+      case DOWNLOADING:
+      case NOT_DOWNLOADED:
+        imageComponent = <ImageComponent src={onlineURL} type={type} {...imageProps} />
+        break
+      case DOWNLOADED:
+        const imagePath = 'manga://' + path.join(
+          specificManga.get('name'),
+          this.props.chapterNum + '',
+          encodeURIComponent(onlineURL)
+        )
+        imageComponent = <img src={imagePath} {...imageProps} />
+        break
+    }
+
+    return (
+      <div>
+        <AppBar
+          title={title}
+          iconElementLeft={<IconButton onClick={this.props.back}><NavigationArrowBack /></IconButton>}
+          iconElementRight={<IconButton onClick={prevClicked}><ContentUndo /></IconButton>}
+          style={{ position: 'fixed' }}
+        />
+        <br /><br /><br /><br />
+        <div style={styles.slider}>
+          <Slider
+            style={{ width: '80%' }}
+            min={1}
+            max={totalPages}
+            step={1}
+            value={this.state.slider}
+            onChange={sliderChanged}
+          />
+          <p style={styles.sliderText}>{this.state.slider}/{totalPages}</p>
+        </div>
+        {imageComponent}
+      </div>
+    )
+  }
 }
 
 ChapterViewComponent.propTypes = {
@@ -56,5 +116,5 @@ ChapterViewComponent.propTypes = {
   mangaName: PropTypes.string.isRequired,
   chapterNum: PropTypes.number.isRequired,
   back: PropTypes.func.isRequired,
-  onImageClicked: PropTypes.func.isRequired
+  update: PropTypes.func.isRequired
 }

--- a/client/components/SliderComponent.js
+++ b/client/components/SliderComponent.js
@@ -1,5 +1,7 @@
 import React, { PropTypes } from 'react'
 import Slider from 'material-ui/Slider'
+import Chip from 'material-ui/Chip'
+import TextField from 'material-ui/TextField'
 
 const styles = {
   slider: {
@@ -7,26 +9,92 @@ const styles = {
     flexDirection: 'row',
     justifyContent: 'space-around'
   },
-  sliderText: {
+  pageNumberDisplay: {
     position: 'relative',
-    top: '5px'
+    top: '18px',
+    height: '30px'
+  },
+  pageNumberEditing: {
+    display: 'flex',
+    width: '10%',
+    flexDirection: 'row',
+    justifyContent: 'space-around'
   }
 }
 
-export default function SliderComponent ({ currValue, totalPages, onSliderChanged }) {
-  return (
-    <div style={styles.slider}>
-      <Slider
-        style={{ width: '80%' }}
-        min={1}
-        max={totalPages}
-        step={1}
-        value={currValue}
-        onChange={(event, newValue) => onSliderChanged(newValue)}
-      />
-      <p style={styles.sliderText}>{currValue}/{totalPages}</p>
-    </div>
-  )
+export default class SliderComponent extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      editing: false,
+      pageText: ''
+    }
+  }
+
+  render () {
+    const editPages = () => this.setState({ editing: true, pageText: this.props.currValue + '' })
+    const pageTextChanged = (event, newValue) => {
+      const num = parseInt(newValue, 10)
+      if (newValue.length === 0 || (!isNaN(num) && num <= this.props.totalPages && num > 0)) {
+        this.setState({ pageText: newValue })
+      }
+    }
+    const savePageText = () => {
+      if (this.state.pageText.length === 0) {
+        this.setState({ pageText: this.props.currValue })
+      } else {
+        this.props.onSliderChanged(parseInt(this.state.pageText, 10))
+      }
+
+      this.setState({ editing: false })
+    }
+    const pageTextKeyPress = (event) => {
+      if (event.key === 'Enter') {
+        savePageText()
+      }
+    }
+    const pageLabel = `${this.props.currValue}/${this.props.totalPages}`
+
+    let currPageComponent = null
+    if (this.state.editing) {
+      currPageComponent = (
+        <div style={styles.pageNumberEditing}>
+          <TextField
+            value={this.state.pageText}
+            onChange={pageTextChanged}
+            onBlur={savePageText}
+            onKeyPress={pageTextKeyPress}
+            autoFocus
+          />
+          <p>/{this.props.totalPages}</p>
+        </div>
+      )
+    } else {
+      currPageComponent = (
+        <Chip
+          style={styles.pageNumberDisplay}
+          onTouchTap={editPages}
+        >
+          {pageLabel}
+        </Chip>
+      )
+    }
+
+    return (
+      <div style={styles.slider}>
+        <Slider
+          style={{ width: '80%' }}
+          min={1}
+          max={this.props.totalPages}
+          step={1}
+          value={this.props.currValue}
+          onChange={(event, newValue) => this.props.onSliderChanged(newValue)}
+        />
+        {currPageComponent}
+      </div>
+    )
+  }
 }
 
 SliderComponent.propTypes = {

--- a/client/components/SliderComponent.js
+++ b/client/components/SliderComponent.js
@@ -1,0 +1,36 @@
+import React, { PropTypes } from 'react'
+import Slider from 'material-ui/Slider'
+
+const styles = {
+  slider: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-around'
+  },
+  sliderText: {
+    position: 'relative',
+    top: '5px'
+  }
+}
+
+export default function SliderComponent ({ currValue, totalPages, onSliderChanged }) {
+  return (
+    <div style={styles.slider}>
+      <Slider
+        style={{ width: '80%' }}
+        min={1}
+        max={totalPages}
+        step={1}
+        value={currValue}
+        onChange={(event, newValue) => onSliderChanged(newValue)}
+      />
+      <p style={styles.sliderText}>{currValue}/{totalPages}</p>
+    </div>
+  )
+}
+
+SliderComponent.propTypes = {
+  currValue: PropTypes.number.isRequired,
+  totalPages: PropTypes.number.isRequired,
+  onSliderChanged: PropTypes.func.isRequired
+}

--- a/client/containers/ChapterViewContainer.js
+++ b/client/containers/ChapterViewContainer.js
@@ -14,12 +14,8 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(goBack())
   },
 
-  onImageClicked (manga, chapterNum) {
-    dispatch(updatePage(manga, chapterNum, 1))
-  },
-
-  onPrevClicked (manga, chapterNum) {
-    dispatch(updatePage(manga, chapterNum, -1))
+  update (manga, chapterNum, amount) {
+    dispatch(updatePage(manga, chapterNum, amount))
   }
 })
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "node-fetch": "^1.6.3",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
+    "react-measure": "^1.4.6",
     "react-redux": "^5.0.1",
     "react-redux-toastr": "^4.4.2",
     "react-router": "^3.0.0",

--- a/utils/scraper.js
+++ b/utils/scraper.js
@@ -6,7 +6,7 @@
  */
 function scrapeChapter (url, adapter) {
   return adapter.sendRequest(url)
-    .then((body) => Promise.resolve(adapter.parsePageLinks(body)))
+    .then((body) => Promise.resolve(adapter.parsePageLinks(url, body)))
     .then((links) => {
       return Promise.all(links.map((link) => {
         return adapter.sendRequest(link)

--- a/utils/sites/mangafreak.js
+++ b/utils/sites/mangafreak.js
@@ -2,14 +2,8 @@ const cheerio = require('cheerio')
 const cloudscraper = require('cloudscraper')
 const { NOT_LOADED, NOT_DOWNLOADED } = require('../constants.js')
 
-function mangaURL (mangaName, chapterNum = null, pageNum = null) {
-  if (chapterNum !== null && pageNum !== null) {
-    return `http://www.mangafreak.net/Read1_${mangaName}_${chapterNum}_${pageNum}#gohere`
-  } else if (chapterNum !== null) {
-    return `http://www.mangafreak.net/Read1_${mangaName}_${chapterNum}`
-  } else {
-    return `http://www.mangafreak.net/Manga/${mangaName}`
-  }
+function mangaURL (mangaName) {
+  return `http://www.mangafreak.net/Manga/${mangaName}`
 }
 
 function sendRequest (url, buffer = false) {
@@ -81,7 +75,7 @@ function parseMangaData (mangaName, body) {
   }
 }
 
-function parsePageLinks (body) {
+function parsePageLinks (url, body) {
   const $ = cheerio.load(body)
 
   let links = []

--- a/utils/sites/mangareader.js
+++ b/utils/sites/mangareader.js
@@ -3,21 +3,12 @@ const fetch = require('node-fetch')
 const { NOT_LOADED, NOT_DOWNLOADED } = require('../constants.js')
 
 /**
- * Returns the URL for the given manga. If chapterNum or pageNum is also
- * specified it returns the URL for the specific chapter or page of the manga.
+ * Returns the URL for the given manga.
  * @param {string} mangaName
- * @param {number|null} chapterNum
- * @param {number|null} pageNum
  * @return {string} the requested URL.
  */
 function mangaURL (mangaName, chapterNum = null, pageNum = null) {
-  if (chapterNum !== null && pageNum !== null) {
-    return `http://www.mangareader.net/${mangaName}/${chapterNum}/${pageNum}`
-  } else if (chapterNum !== null) {
-    return `http://www.mangareader.net/${mangaName}/${chapterNum}`
-  } else {
-    return `http://www.mangareader.net/${mangaName}`
-  }
+  return `http://www.mangareader.net/${mangaName}`
 }
 
 /**
@@ -90,10 +81,11 @@ function parseMangaData (mangaName, body) {
 
 /**
  * Parses the html body and returns an array of URLs to the pages of the chapter.
+ * @param {string} url the chapter URL
  * @param {string} body
  * @return {[string]} the page links in the chapter.
  */
-function parsePageLinks (body) {
+function parsePageLinks (url, body) {
   const $ = cheerio.load(body)
 
   let links = []

--- a/utils/sites/mangareader.js
+++ b/utils/sites/mangareader.js
@@ -7,7 +7,7 @@ const { NOT_LOADED, NOT_DOWNLOADED } = require('../constants.js')
  * @param {string} mangaName
  * @return {string} the requested URL.
  */
-function mangaURL (mangaName, chapterNum = null, pageNum = null) {
+function mangaURL (mangaName) {
   return `http://www.mangareader.net/${mangaName}`
 }
 


### PR DESCRIPTION
Improves page navigation by:

1. Determining from where you clicked on the manga image whether to go to the next or previous page. Clicking the right side of the image will take you to the next page and clicking the left side will take you to the previous page.
2. Adding a slider so that you can scroll through the pages or jump to an estimated point in the chapter.
3. Adding a page number display where you can directly jump to a specific page number.
4. Both the slider and the page number display are hidden by default and will be shown when clicking the down arrow button in the top bar.

It also includes modifications to the manga site API. It changes the parsePageLinks method to include the chapter url and removes unnecessary chapterNum and pageNum parameters from the mangaURL method.