### PR TITLE
Packages into electron app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+release-builds/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 release-builds/
+build/

--- a/README.md
+++ b/README.md
@@ -17,8 +17,15 @@ A desktop manga reader in Javascript using React and Redux.
 
 ## Running
 
-In order to build and run manga-js, you have to first have npm installed. Then run `npm install` in the project directory
-and then `npm start` to start the electron application.
+In order to build and run manga-js, you have to first have npm installed. Then run `npm install` in the project directory to install the dependencies.
+
+If you want to run manga-js in development mode you can just run `npm start`.
+
+If you want to build the packaged electron app you should run `npm run build` to compile the front end Javascript and
+then run either `npm run package-mac` `npm run package-windows` or `npm run package-linux` to package the app.
+The packaged app will be in the release-builds folder.
+Because the app will always try to use the compiled Javascript bundle over the normal code, if you want to go back into development mode you have to
+remove the build/bundle.js file created from `npm run build`.
 
 ## Supported sites
 

--- a/__tests__/BulkSender.spec.js
+++ b/__tests__/BulkSender.spec.js
@@ -1,6 +1,6 @@
 /* global test, expect, jest */
 
-import { BulkSender } from '../utils/process.js'
+import BulkSender from '../utils/BulkSender.js'
 
 jest.useFakeTimers()
 

--- a/client/components/ImageComponent.js
+++ b/client/components/ImageComponent.js
@@ -3,7 +3,7 @@
 import React, { PropTypes } from 'react'
 import Avatar from 'material-ui/Avatar'
 import { adapterFromURL, fileExtFromURL } from '../../utils/url.js'
-import mimetype from 'mimetype'
+import mime from 'mime-types'
 import Measure from 'react-measure'
 
 export default class ImageComponent extends React.Component {
@@ -27,7 +27,7 @@ export default class ImageComponent extends React.Component {
   retrieveImage (src) {
     this.adapter.sendRequest(src, true).then((buffer) => {
       const fileExt = fileExtFromURL(src)
-      const fileType = mimetype.lookup(`sample.${fileExt}`)
+      const fileType = mime.lookup(`.${fileExt}`)
       const blob = new Blob([buffer], { type: fileType })
       const url = URL.createObjectURL(blob)
       this.setState({ src: url })

--- a/downloaderUtils.js
+++ b/downloaderUtils.js
@@ -1,0 +1,38 @@
+const bluebird = require('bluebird')
+const fse = bluebird.promisifyAll(require('fs-extra'))
+const loc = require('./utils/location.js')
+
+function downloadChapter (event, args, queue) {
+  event.sender.send('recv-download-chapter', Object.assign({}, args, { err: null }))
+  const { mangaName, chapterNum, type } = args
+
+  // Enqueue download tasks for each image.
+  args.pages.forEach((url, i) => {
+    queue.enqueue({
+      mangaName,
+      chapterNum,
+      type,
+      url,
+      total: args.pages.length,
+      curr: i
+    })
+  })
+}
+
+function deleteChapter (basePath, args) {
+  const path = loc.chapterPath(basePath, args.mangaName, args.chapterNum)
+
+  return fse.removeAsync(path)
+}
+
+function deleteManga (basePath, args) {
+  const path = loc.mangaPath(basePath, args.mangaName)
+
+  return fse.removeAsync(path)
+}
+
+module.exports = {
+  downloadChapter,
+  deleteChapter,
+  deleteManga
+}

--- a/index.html
+++ b/index.html
@@ -8,7 +8,18 @@
     <!-- Starting point for React app -->
     <div id="app"></div>
 
-    <script>require('babel-register')</script>
-    <script>require('./client/index.js')</script>
+    <script>
+      var fs = require('fs')
+      var path = require('path')
+      var bundlePath = path.join(__dirname, './build/bundle.js')
+
+      if (fs.existsSync(bundlePath)) {
+        require('./build/bundle.js')
+      } else {
+        console.log('Development mode')
+        require('babel-register')
+        require('./client/index.js')
+      }
+    </script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,20 +5,22 @@
   "main": "index.js",
   "scripts": {
     "start": "electron .",
-    "test": "jest"
+    "test": "jest",
+    "package-mac": "electron-packager . --overwrite --platform=darwin --arch=x64 --prune=true --out=release-builds"
   },
   "author": "Darin Minamoto",
   "license": "GNU GPL 3",
   "devDependencies": {
     "babel-jest": "^18.0.0",
-    "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "electron": "^1.4.13",
+    "electron-packager": "^8.5.2",
     "jest": "^18.1.0",
     "react-test-renderer": "^15.4.1"
   },
   "dependencies": {
     "babel-core": "^6.21.0",
     "babel-plugin-transform-react-jsx": "^6.8.0",
+    "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "babel-preset-es2015": "^6.18.0",
     "babel-register": "^6.18.0",
     "bluebird": "^3.4.7",
@@ -41,5 +43,11 @@
     "redux": "^3.6.0",
     "redux-logger": "^2.7.4",
     "redux-thunk": "^2.1.0"
+  },
+  "jest": {
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/release-builds/"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "electron .",
     "test": "jest",
-    "build": "webpack",
+    "build": "webpack -p",
     "package-mac": "electron-packager . --overwrite --platform=darwin --arch=x64 --prune=true --out=release-builds",
     "package-windows": "electron-packager . --overwrite --asar=true --platform=win32 --arch=ia32 --prune=true --out=release-builds --version-string.CompanyName=DM --version-string.FileDescription=DM --version-string.ProductName=\"Manga-JS\"",
     "package-linux": "electron-packager . --overwrite --platform=linux --arch=x64 --prune=true --out=release-builds"
@@ -53,7 +53,8 @@
   "jest": {
     "testPathIgnorePatterns": [
       "/node_modules/",
-      "/release-builds/"
+      "/release-builds/",
+      "/build/"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "start": "electron .",
     "test": "jest",
-    "package-mac": "electron-packager . --overwrite --platform=darwin --arch=x64 --prune=true --out=release-builds"
+    "package-mac": "electron-packager . --overwrite --platform=darwin --arch=x64 --prune=true --out=release-builds",
+    "package-windows": "electron-packager . --overwrite --asar=true --platform=win32 --arch=ia32 --prune=true --out=release-builds --version-string.CompanyName=DM --version-string.FileDescription=DM --version-string.ProductName=\"Manga-JS\"",
+    "package-linux": "electron-packager . --overwrite --platform=linux --arch=x64 --prune=true --out=release-builds"
   },
   "author": "Darin Minamoto",
   "license": "GNU GPL 3",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "electron .",
     "test": "jest",
+    "build": "webpack",
     "package-mac": "electron-packager . --overwrite --platform=darwin --arch=x64 --prune=true --out=release-builds",
     "package-windows": "electron-packager . --overwrite --asar=true --platform=win32 --arch=ia32 --prune=true --out=release-builds --version-string.CompanyName=DM --version-string.FileDescription=DM --version-string.ProductName=\"Manga-JS\"",
     "package-linux": "electron-packager . --overwrite --platform=linux --arch=x64 --prune=true --out=release-builds"
@@ -14,15 +15,18 @@
   "license": "GNU GPL 3",
   "devDependencies": {
     "babel-jest": "^18.0.0",
+    "babel-loader": "^6.4.0",
+    "babel-preset-env": "^1.2.1",
     "electron": "^1.4.13",
     "electron-packager": "^8.5.2",
     "jest": "^18.1.0",
-    "react-test-renderer": "^15.4.1"
+    "react-test-renderer": "^15.4.1",
+    "webpack": "^2.2.1"
   },
   "dependencies": {
     "babel-core": "^6.21.0",
-    "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
+    "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-register": "^6.18.0",
     "bluebird": "^3.4.7",
@@ -32,7 +36,7 @@
     "immutable": "^3.8.1",
     "lodash": "^4.17.3",
     "material-ui": "^0.16.5",
-    "mimetype": "0.0.8",
+    "mime-types": "^2.1.14",
     "node-fetch": "^1.6.3",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",

--- a/utils/BulkSender.js
+++ b/utils/BulkSender.js
@@ -1,5 +1,3 @@
-const { startQueue } = require('./downloadQueue.js')
-
 /**
  * Sends a bunch of messages in a specified interval
  * in order to reduce the amount of messages needed to be sent
@@ -53,28 +51,4 @@ class BulkSender {
   }
 }
 
-function downloadProcessHandler (path, file) {
-  const sender = new BulkSender((bulkMsg) => process.send(bulkMsg))
-  startQueue(path, file, (msg) => sender.add(msg)).then((queue) => {
-    process.send({ start: true })
-    process.on('message', (msg) => {
-      const { mangaName, chapterNum, type } = msg
-      // Enqueue download tasks for each image.
-      msg.pages.forEach((url, i) => {
-        queue.enqueue({
-          mangaName,
-          chapterNum,
-          type,
-          url,
-          total: msg.pages.length,
-          curr: i
-        })
-      })
-    })
-  })
-}
-
-module.exports = {
-  BulkSender,
-  downloadProcessHandler
-}
+module.exports = BulkSender

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require('path')
+
+module.exports = {
+  entry: './client/index.js',
+  target: 'electron',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'build')
+  },
+  node: {
+    global: true,
+    __dirname: true,
+    __filename: true
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js?$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        query: {
+          presets: ['env']
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds scripts to compile the front end JS into a file to speed up app loading times, and to package the app to be easily ran from Windows, Mac, and Linux.

Other changes:
- Reverts code that puts downloader into separate process because it was causing channel closed problems when the app is packaged and there isn't enough benchmarks yet to show that it is improving performance.
- Replaces the package 'mimetype' to 'mime-types' for looking up content types because 'mime-types' compiles properly under webpack.
- Downloader process code is moved into downloader.js so it could be used by child_process.fork when downloader process code is fixed and benchmarked.